### PR TITLE
Fix for nil reference during scale transform

### DIFF
--- a/lua/ponder/instructions_cl/models/ponder.transformmodel.lua
+++ b/lua/ponder/instructions_cl/models/ponder.transformmodel.lua
@@ -51,9 +51,9 @@ function TransformModel:Update(playback)
     end
 
     if object.PONDER_TARG_SCA then
-        mdl.Scale = LerpVector(progress, object.PONDER_LAST_SCA, object.PONDER_TARG_SCA)
+        object.Scale = LerpVector(progress, object.PONDER_LAST_SCA, object.PONDER_TARG_SCA)
         local mat = Matrix()
-        mat:Scale(mdl.Scale)
-        mdl:EnableMatrix("RenderMultiply", mat)
+        mat:Scale(object.Scale)
+        object:EnableMatrix("RenderMultiply", mat)
     end
 end


### PR DESCRIPTION
Instruction references `mdl` which isn't defined in this function, switching it to `object` corrects this error.
![image](https://github.com/user-attachments/assets/2335e023-dbdd-486a-89df-a2f34fb9a294)

(after change)
![scale](https://github.com/user-attachments/assets/6c07671c-1ec5-4622-ab57-be456d7e0636)
